### PR TITLE
feat: Defeat Game, AI Alert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,7 @@ sysinfo.txt
 # Builds
 *.apk
 *.aab
-*.unitypackage
+#*.unitypackage
 *.app
 
 # Crashlytics generated file

--- a/2022_KPU_ShotsFired_main/Assets/Resources/Prototype Enemy.prefab
+++ b/2022_KPU_ShotsFired_main/Assets/Resources/Prototype Enemy.prefab
@@ -641,7 +641,7 @@ MonoBehaviour:
   ObservedComponents:
   - {fileID: -9039183854476863617}
   IsMine: 1
-  sceneViewId: 2
+  sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
 --- !u!114 &-9039183854476863617

--- a/2022_KPU_ShotsFired_main/Assets/Resources/Prototype Player.prefab
+++ b/2022_KPU_ShotsFired_main/Assets/Resources/Prototype Player.prefab
@@ -948,7 +948,7 @@ MonoBehaviour:
   maxSuppress: 100
   unsuppressAmount: 7
   state: 0
-  restoreStartTime: 5
+  restoreStartTime: 2
   autoRestoreAmount: 10
   downMaxHealth: 50
 --- !u!114 &4168991318271931823
@@ -972,7 +972,7 @@ MonoBehaviour:
   ObservedComponents:
   - {fileID: 706556014673934}
   IsMine: 1
-  sceneViewId: 1
+  sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
 --- !u!114 &706556014673934

--- a/2022_KPU_ShotsFired_main/Assets/Scenes/Main Scene.unity
+++ b/2022_KPU_ShotsFired_main/Assets/Scenes/Main Scene.unity
@@ -2164,6 +2164,17 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2109610837}
   m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &2118420079 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4401816778765267646, guid: 612b4824ecec58042a32de80adf37936, type: 3}
+  m_PrefabInstance: {fileID: 733401170682080172}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7e451c466a141e947b283eb5b26cf2b9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &733401170682080172
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2508,6 +2519,14 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 8552581442652315653}
     - target: {fileID: 5693004795008369823, guid: 3a20debef9fa2ba499fad30abd6addb5, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5693004795008369823, guid: 3a20debef9fa2ba499fad30abd6addb5, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5693004795008369823, guid: 3a20debef9fa2ba499fad30abd6addb5, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 318697133}
@@ -2515,6 +2534,26 @@ PrefabInstance:
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
       value: 
       objectReference: {fileID: 8552581442652315653}
+    - target: {fileID: 5693004795008369823, guid: 3a20debef9fa2ba499fad30abd6addb5, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_Target
+      value: 
+      objectReference: {fileID: 2118420079}
+    - target: {fileID: 5693004795008369823, guid: 3a20debef9fa2ba499fad30abd6addb5, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5693004795008369823, guid: 3a20debef9fa2ba499fad30abd6addb5, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_MethodName
+      value: StartGame
+      objectReference: {fileID: 0}
+    - target: {fileID: 5693004795008369823, guid: 3a20debef9fa2ba499fad30abd6addb5, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_TargetAssemblyTypeName
+      value: GameManager, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 5693004795008369823, guid: 3a20debef9fa2ba499fad30abd6addb5, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[2].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
     - target: {fileID: 5693004795278077151, guid: 3a20debef9fa2ba499fad30abd6addb5, type: 3}
       propertyPath: m_IsActive
       value: 1
@@ -2779,7 +2818,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b36eee3823eb55f4989ea04221384d54, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  PV: {fileID: 0}
   nickname: {fileID: 1123881215}
   roomname: {fileID: 108470238}
   Lobby_roomName: {fileID: 1086717112}

--- a/2022_KPU_ShotsFired_main/Assets/Scripts/Enemy/AIManager.cs
+++ b/2022_KPU_ShotsFired_main/Assets/Scripts/Enemy/AIManager.cs
@@ -17,9 +17,13 @@ public class AIManager : MonoBehaviourPunCallbacks
     public override void OnEnable() 
     {
         if(isUsed) return;
-        isUsed = true;
         stageManager = transform.root.Find("SafeRoom Trigger").GetComponent<StageManager>();    
         RespawnAI();
+    }
+    
+    public override void OnDisable() 
+    {
+        isUsed = true;
     }
 
     private void Update() 
@@ -40,6 +44,7 @@ public class AIManager : MonoBehaviourPunCallbacks
             {
                 var obj = PhotonNetwork.Instantiate(enemies[i].name , transform.position, transform.rotation);
                 SceneManager.MoveGameObjectToScene(obj, gameObject.scene);
+                obj.GetComponent<EnemyAgent>().SetAlert();
                 stageManager.AddAI(obj);
             }
         }

--- a/2022_KPU_ShotsFired_main/Assets/Scripts/Enemy/EnemyAgent.cs
+++ b/2022_KPU_ShotsFired_main/Assets/Scripts/Enemy/EnemyAgent.cs
@@ -293,5 +293,13 @@ class EnemyAgent : LivingEntity
         attackerTargetWeight = enemyData.AttackerTargetWeight;
         moveSpeed = enemyData.MoveSpeed;
     }
+
+    // 경계(이동 또는 전투)상태가 되며, 게임 매니저로 부터 플레이어의 정보를 가져온다.
+    public void SetAlert()
+    {
+        players = GameManager.Instance.players;
+
+        curState = AIState.move;
+    }
     #endregion
 }

--- a/2022_KPU_ShotsFired_main/Assets/Scripts/Managers/GameManager.cs
+++ b/2022_KPU_ShotsFired_main/Assets/Scripts/Managers/GameManager.cs
@@ -6,7 +6,8 @@ public class GameManager : MonoBehaviour
 {
    #region 전역 동작 변수
    public int curLivingPlayer;  // 현재 게임의 살아있는 플레이어 수
-   private int[] curPlayerCount = new int[4];   // 플레이어 ID 풀: 0-없음, 1-있음, 0번 ID-ID발급 거부
+   public GameObject[] players = new GameObject[4];   // 플레이어 ID 풀, 플레이어의 gameobject로 관리
+   bool ispPlaying;  // 게임이 진행 중인지 여부
    #endregion
 
     //싱글톤
@@ -20,14 +21,19 @@ public class GameManager : MonoBehaviour
         }
     }
 
+    private void Update() 
+    {
+        ObserveDefeatGame();
+    }
+
     // 플레이어 ID부여
-    public int GetID()
+    public int GetID(GameObject _player)
     {   
         for(int i=0; i < 4 ; i++)
         {
-            if(curPlayerCount[i] == 0)
+            if(players[i] == null)
             {
-                curPlayerCount[i] = 1;
+                players[i] = _player;
                 curLivingPlayer++;
                 return i+1 ;
             }
@@ -40,7 +46,33 @@ public class GameManager : MonoBehaviour
     public void ReturnID(int _ID)
     {
         if(_ID == 0 ) return;
-        curPlayerCount[_ID-1] = 0;
+        players[_ID-1] = null;
         curLivingPlayer--;
+    }
+
+    // 게임 시작
+    public void StartGame()
+    {
+        ispPlaying = true;
+    }
+
+    // 게임 종료
+    public void EndGame(bool _isVictory)
+    {
+        // UI 처리
+        GameUIManager.Instance.SetActiveReport(true);
+        GameUIManager.Instance.SetActivePlayer(false);
+        GameUIManager.Instance.SetMouseLock(false);
+
+        // 오브젝트 처리
+        PhotonInit.PhotonInit.Instance.end_game();
+
+        ispPlaying = false;
+    }
+
+    // 게임 패배 감지
+    private void ObserveDefeatGame()
+    {
+        if(curLivingPlayer <= 0 && ispPlaying) EndGame(false);
     }
 }

--- a/2022_KPU_ShotsFired_main/Assets/Scripts/Managers/StageManager.cs
+++ b/2022_KPU_ShotsFired_main/Assets/Scripts/Managers/StageManager.cs
@@ -55,11 +55,7 @@ public class StageManager : MonoBehaviour
             }
             else    // 마지막 스테이지일 때
             {
-                GameUIManager.Instance.SetActiveReport(true);
-                GameUIManager.Instance.SetActivePlayer(false);
-                GameUIManager.Instance.SetMouseLock(false);
-
-                PhotonInit.PhotonInit.Instance.end_game();
+               GameManager.Instance.EndGame(true);
 
                 if (prevSceneName != "") StartCoroutine(GameSceneManager.Instance.UnloadSceneWithAsync(prevSceneName));
                 

--- a/2022_KPU_ShotsFired_main/Assets/Scripts/Player/PlayerController.cs
+++ b/2022_KPU_ShotsFired_main/Assets/Scripts/Player/PlayerController.cs
@@ -12,7 +12,7 @@ public class PlayerController : MonoBehaviour
 
     private void OnEnable() 
     {
-        ID = GameManager.Instance.GetID();
+        ID = GameManager.Instance.GetID(this.gameObject);
     }
 
     private void OnDisable() 

--- a/2022_KPU_ShotsFired_main/Assets/Scripts/Player/PlayerHealth.cs
+++ b/2022_KPU_ShotsFired_main/Assets/Scripts/Player/PlayerHealth.cs
@@ -60,7 +60,8 @@ class PlayerHealth : LivingEntity
             UpdateUI();
             curHealth = downMaxHealth;
             
-            playerController.ableControlMove = false;
+            playerController.ableControlMove = false;   // 이동 불능
+            GameManager.Instance.curLivingPlayer--; // 생존 플레이어 수 감소
         }
         else if( state == EntityState.down) 
         {


### PR DESCRIPTION
1. 깃허브 ignore에 패키지매니저 주석처리
프로젝트를 지우고 다시 설치할 떄마다, 패키지를 다시 설치하기 번거로워, 주석처리를 합니다.
(문제시 다시 활성화 예정)

2. 게임 패배 감지
게임 내 모든 플레이어가 '죽음' 상태이면, 게임 종료됩니다.
(추후 디자인 측면의 디테일업 필요)

GameManager.cs가 관리함

3. AI 경계상태 관리
리스폰 된 AI는 리스폰되는 시점에,
모든 플레이어의 정보를 가지며, Move상태가 되어,
플레이어들에게 접근합니다.

AIManager.cs가 AI를 리스폰 시키면서, EnemyAgent.cs의 SetAlert()를 실행시켜 작동합니다.